### PR TITLE
Feature/80   student routing

### DIFF
--- a/__tests__/integration/routes/+layout.server.test.ts
+++ b/__tests__/integration/routes/+layout.server.test.ts
@@ -44,6 +44,7 @@ describe('Layout Server Load Function', () => {
 
 		expect(result).toEqual({ user: { name: 'John Doe', role: 'Student' } });
 		expect(fetchUserData).toHaveBeenCalledWith(backendUrl, api_version, 'valid_token');
+		expect(get_user_role).toHaveBeenCalledWith('valid_token');
 	});
 
 	it('refreshes access token and fetch user data if access token is expired', async () => {

--- a/__tests__/integration/routes/+layout.server.test.ts
+++ b/__tests__/integration/routes/+layout.server.test.ts
@@ -74,7 +74,7 @@ describe('Layout Server Load Function', () => {
 		expect(result).toEqual({ user: { name: 'Jane Doe', role: 'Student' } });
 		expect(fetch).toHaveBeenCalledWith(`${backendUrl}/refresh`, expect.any(Object));
 		expect(fetchUserData).toHaveBeenCalledWith(backendUrl, api_version, 'new_access_token');
-
+		
 		expect(mockCookies.set).toHaveBeenCalledWith(
 			'access_token',
 			'new_access_token',

--- a/__tests__/integration/routes/+layout.test.ts
+++ b/__tests__/integration/routes/+layout.test.ts
@@ -8,12 +8,12 @@ vi.mock('@sveltejs/kit', () => ({
 
 describe('load function', () => {
 	it('redirects to the home page if a logged-in user accesses /login', () => {
-		const mockUser = { name: 'John Doe' };
+		const mockUser = { name: 'John Doe', role: "Student" };
 		const data = { user: mockUser };
 		const url = { pathname: '/login' };
 
 		expect(() => load({ data, url })).toThrow();
-		expect(redirect).toHaveBeenCalledWith(303, '/login');
+		expect(redirect).toHaveBeenCalledWith(303, '/');
 	});
 
 	it('returns user data if no redirect is needed', () => {
@@ -45,9 +45,9 @@ describe('get_anon_userID', () => {
 	});
 
 	it('should redirect authorized user when accessing login url ', () => {
-		const user = { name: 'Andreas' };
+		const user = { name: 'Andreas', role: "Student" };
 		const url_path = '/login';
 		expect(() => _validate_url_path(user, url_path)).toThrow();
-		expect(redirect).toHaveBeenCalledWith(303, '/login');
+		expect(redirect).toHaveBeenCalledWith(303, '/');
 	});
 });

--- a/__tests__/unit/lib/getrole.test.ts
+++ b/__tests__/unit/lib/getrole.test.ts
@@ -8,4 +8,11 @@ describe("get_user_role", () => {
         const result = get_user_role(input);
         expect(result).toEqual(expected);
     });
+
+    test("Should return default value if unable to decode token", () =>{
+        const expected = "AnonymousUser";
+        const input = "eruwg";
+        const result = get_user_role(input);
+        expect(result).toEqual(expected);
+    });
 });

--- a/__tests__/unit/lib/getrole.test.ts
+++ b/__tests__/unit/lib/getrole.test.ts
@@ -1,0 +1,11 @@
+import { describe, test, expect } from 'vitest';
+import { get_user_role } from '$lib/getrole';
+
+describe("get_user_role", () => {
+    test("Should correctly decode jwt token to get role", () => {
+        const expected = "Student";
+        const input = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJodHRwOi8vc2NoZW1hcy5taWNyb3NvZnQuY29tL3dzLzIwMDgvMDYvaWRlbnRpdHkvY2xhaW1zL3VzZXJkYXRhIjoiMiIsImh0dHA6Ly9zY2hlbWFzLm1pY3Jvc29mdC5jb20vd3MvMjAwOC8wNi9pZGVudGl0eS9jbGFpbXMvcm9sZSI6IlN0dWRlbnQiLCJleHAiOjE3MzIwMDg5NTEsImlzcyI6IkJhY2tlbmRlciIsImF1ZCI6IkZyb250ZW5kIn0.lc_W_qOs6WAo6xTtW57Us_FSm1ythQu5FFnMhM0lMYw";
+        const result = get_user_role(input);
+        expect(result).toEqual(expected);
+    });
+});

--- a/__tests__/unit/routes/login/+page.server.faillogin.test.ts
+++ b/__tests__/unit/routes/login/+page.server.faillogin.test.ts
@@ -55,7 +55,7 @@ describe('login action function', () => {
         const result = await actions.default(event);
 
         // Assert 
-        expect(setError).toHaveBeenCalledWith(expect.any(Object), 'email', 'Invalid credentials');
+        expect(setError).toHaveBeenCalledWith(expect.any(Object), 'password', 'Invalid credentials');
        
     });
 });

--- a/src/lib/getrole.ts
+++ b/src/lib/getrole.ts
@@ -10,6 +10,6 @@ export function get_user_role(access_token: string) {
 		}
 	} catch (error) {
 		console.error('Invalid access_token', error.message);
-        return null
+        return 'AnonymousUser'
 	}
 }

--- a/src/lib/getrole.ts
+++ b/src/lib/getrole.ts
@@ -1,0 +1,15 @@
+import { jwtDecode } from 'jwt-decode';
+
+export function get_user_role(access_token: string) {
+	try {
+		const decoded_token = jwtDecode(access_token) as {
+			'http://schemas.microsoft.com/ws/2008/06/identity/claims/role': string;
+		};
+		if (decoded_token) {
+			return decoded_token['http://schemas.microsoft.com/ws/2008/06/identity/claims/role'];
+		}
+	} catch (error) {
+		console.error('Invalid access_token', error.message);
+        return null
+	}
+}

--- a/src/routes/+layout.server.ts
+++ b/src/routes/+layout.server.ts
@@ -23,7 +23,7 @@ export const load: LayoutServerLoad = async ({ cookies }) => {
 	let userData;
 	if (response.ok) {
 		userData = await response.json();
-		const access_token_: string = cookies.get('access_token') || 'AnonymousUser';
+		const access_token_: string = cookies.get('access_token') || '';
 		userRole = get_user_role(access_token_);
 	}
 	return {

--- a/src/routes/+layout.server.ts
+++ b/src/routes/+layout.server.ts
@@ -23,7 +23,8 @@ export const load: LayoutServerLoad = async ({ cookies }) => {
 	let userData;
 	if (response.ok) {
 		userData = await response.json();
-		userRole = get_user_role(access_token);
+		const access_token_: string = cookies.get('access_token') || '';
+		userRole = get_user_role(access_token_);
 	}
 	return {
 		user: userData && userRole? { name: userData.name, role: userRole } : null

--- a/src/routes/+layout.server.ts
+++ b/src/routes/+layout.server.ts
@@ -24,6 +24,6 @@ export const load: LayoutServerLoad = async ({ cookies }) => {
 		userData = await response.json();
 	}
 	return {
-		user: userData ? { name: userData.name } : null
+		user: userData ? { name: userData.name, role: "student" } : null
 	};
 };

--- a/src/routes/+layout.server.ts
+++ b/src/routes/+layout.server.ts
@@ -1,6 +1,7 @@
 import type { LayoutServerLoad } from './$types';
 import { fetchUserData } from '$lib/fetchRequests';
 import { handleAuthenticatedRequest } from '$lib/requestHandler';
+import { get_user_role } from '$lib/getrole';
 
 export const load: LayoutServerLoad = async ({ cookies }) => {
 	const backendUrl = import.meta.env.VITE_BACKEND_URL;
@@ -18,12 +19,13 @@ export const load: LayoutServerLoad = async ({ cookies }) => {
 		refresh_token,
 		cookies
 	);
-
+	let userRole;
 	let userData;
 	if (response.ok) {
 		userData = await response.json();
+		userRole = get_user_role(access_token);
 	}
 	return {
-		user: userData ? { name: userData.name, role: "student" } : null
+		user: userData && userRole? { name: userData.name, role: userRole } : null
 	};
 };

--- a/src/routes/+layout.server.ts
+++ b/src/routes/+layout.server.ts
@@ -23,7 +23,7 @@ export const load: LayoutServerLoad = async ({ cookies }) => {
 	let userData;
 	if (response.ok) {
 		userData = await response.json();
-		const access_token_: string = cookies.get('access_token') || '';
+		const access_token_: string = cookies.get('access_token') || 'AnonymousUser';
 		userRole = get_user_role(access_token_);
 	}
 	return {

--- a/src/routes/+layout.ts
+++ b/src/routes/+layout.ts
@@ -17,6 +17,7 @@ export function _validate_url_path(user: { name: string, role: string } | null, 
 		throw redirect(303, '/');
 	}
 
+	//Allowed endpoints anon
 	if (
 		!user &&
 		urlp !== '/join' &&
@@ -28,8 +29,9 @@ export function _validate_url_path(user: { name: string, role: string } | null, 
 	) {
 		throw redirect(303, '/');
 	}
+	//Allowed endpoints student
 	else if (
-		user?.role === "student" &&
+		user?.role === "Student" &&
 		urlp !== '/join' &&
 		!urlp.startsWith('/session') &&
 		urlp !== '/' &&
@@ -37,8 +39,9 @@ export function _validate_url_path(user: { name: string, role: string } | null, 
 	) {
 		throw redirect(303, '/')
 	}
+	//disallowed endpoints instructor
 	else if (
-		user?.role === "instructor" &&
+		user?.role === "Instructor" &&
 		urlp === 'signup' ||
 		urlp === 'login'
 	) {

--- a/src/routes/+layout.ts
+++ b/src/routes/+layout.ts
@@ -12,9 +12,9 @@ export const load: LayoutLoad = ({ data, url }) => {
 	};
 };
 
-export function _validate_url_path(user: { name: string } | null, urlp: string) {
+export function _validate_url_path(user: { name: string, role: string } | null, urlp: string) {
 	if (user && urlp === '/login') {
-		throw redirect(303, urlp);
+		throw redirect(303, '/');
 	}
 
 	if (
@@ -27,5 +27,14 @@ export function _validate_url_path(user: { name: string } | null, urlp: string) 
 		urlp !== '/signup'
 	) {
 		throw redirect(303, '/');
+	}
+	else if (
+		user?.role === "student" &&
+		urlp !== '/join' &&
+		!urlp.startsWith('/session') &&
+		urlp !== '/' &&
+		urlp !== '/exercise'
+	) {
+		throw redirect(303, '/')
 	}
 }

--- a/src/routes/+layout.ts
+++ b/src/routes/+layout.ts
@@ -12,36 +12,34 @@ export const load: LayoutLoad = ({ data, url }) => {
 	};
 };
 
-export function _validate_url_path(user: { name: string, role: string } | null, urlp: string) {
+export function _validate_url_path(user: { name: string, role: string } | null, urlp: string) {	
+	const allowedAnonRoutes = [
+		'/join', '/login', '/', '/signup', '/exercise', '/session'
+	];
+	const allowedStudentRoutes = [
+		'/join', '/exercise', '/session', '/'
+	];
+	const allowedInstructorRoutes = [
+		'/join', '/exercise', '/', '/session', '/create-session', '/createexercise'
+	];
 	
-	//Allowed endpoints anon
-	if (
-		!user &&
-		urlp !== '/join' &&
-		!urlp.startsWith('/session') &&
-		urlp !== '/login' &&
-		urlp !== '/' &&
-		urlp !== '/exercise' &&
-		urlp !== '/signup'
-	) {
+	if (user && urlp === '/login') {
 		throw redirect(303, '/');
 	}
-	//Allowed endpoints student
-	else if (
-		user?.role === "Student" &&
-		urlp !== '/join' &&
-		!urlp.startsWith('/session') &&
-		urlp !== '/' &&
-		urlp !== '/exercise'
-	) {
-		throw redirect(303, '/')
+
+	if (!user || user.role === 'AnonymousUser') {
+		if (!allowedAnonRoutes.includes(urlp) && !urlp.startsWith('/session')) {
+			throw redirect(303, '/');
+		}
 	}
-	//disallowed endpoints instructor
-	else if (
-		user?.role === "Instructor" &&
-		urlp === 'signup' ||
-		urlp === 'login'
-	) {
-		throw redirect(303, '/')
+	else if (user.role === 'Student') {
+		if (!allowedStudentRoutes.includes(urlp) && !urlp.startsWith('/session')) {
+			throw redirect(303, '/');
+		}
+	}
+	else if (user.role === 'Instructor') {
+		if (!allowedInstructorRoutes.includes(urlp)) {
+			throw redirect(303, '/');
+		}
 	}
 }

--- a/src/routes/+layout.ts
+++ b/src/routes/+layout.ts
@@ -13,10 +13,7 @@ export const load: LayoutLoad = ({ data, url }) => {
 };
 
 export function _validate_url_path(user: { name: string, role: string } | null, urlp: string) {
-	if (user && urlp === '/login') {
-		throw redirect(303, '/');
-	}
-
+	
 	//Allowed endpoints anon
 	if (
 		!user &&

--- a/src/routes/+layout.ts
+++ b/src/routes/+layout.ts
@@ -37,4 +37,11 @@ export function _validate_url_path(user: { name: string, role: string } | null, 
 	) {
 		throw redirect(303, '/')
 	}
+	else if (
+		user?.role === "instructor" &&
+		urlp === 'signup' ||
+		urlp === 'login'
+	) {
+		throw redirect(303, '/')
+	}
 }

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -58,7 +58,7 @@
 	}
 </script>
 
-{#if data.user}
+{#if data.user?.role === "instructor"}
 	<div class="container pl-6 w-full text-[#333] grid grid-cols-1 gap-y-8">
 		<h1 class="text-2xl font-semibold col-span-full">Instructor Home</h1>
 		<div class="flex gap-x-12 h-full">
@@ -140,12 +140,14 @@
 			
 			<!-- Buttons -->
 			<div class="space-y-4">
+				{#if !data.user}
 				<Button href="/login" class="w-full bg-blue-500 hover:bg-blue-600 text-white">
 					Log In
 				</Button>
 				<Button href="/signup" class="w-full bg-green-500 hover:bg-green-600 text-white">
 					Sign Up
 				</Button>
+				{/if}
 				<Button href="/join" class="w-full bg-purple-500 hover:bg-purple-600 text-white">
 					Join a Room
 				</Button>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -58,7 +58,7 @@
 	}
 </script>
 
-{#if data.user?.role === "instructor"}
+{#if data.user?.role === "Instructor"}
 	<div class="container pl-6 w-full text-[#333] grid grid-cols-1 gap-y-8">
 		<h1 class="text-2xl font-semibold col-span-full">Instructor Home</h1>
 		<div class="flex gap-x-12 h-full">

--- a/src/routes/login/+page.server.ts
+++ b/src/routes/login/+page.server.ts
@@ -54,7 +54,7 @@ export const actions: Actions = {
 			throw redirect(303, '/');
 		} else {
 			const error = await response.json();
-			return setError(form, 'email', error?.detail || 'Login failed');
+			return setError(form, 'password', error?.detail || 'Wrong Email or Password');
 		}
 	}
 };

--- a/src/routes/signup/+page.server.ts
+++ b/src/routes/signup/+page.server.ts
@@ -38,7 +38,7 @@ export const actions: Actions = {
       });
     } else {
       const error = await response.json();
-      return setError(form, 'confirmPassword', error?.detail || 'Signup failed!');
+      return setError(form, 'confirmPassword', error.errors.Password.join('\n') || "Signup failed");
     }
   },
 };

--- a/src/routes/signup/sign-up-schema.ts
+++ b/src/routes/signup/sign-up-schema.ts
@@ -1,5 +1,6 @@
 // schema.ts
 import { z } from 'zod';
+const passwordRegex = /[!@#$%^&*(),.?":{}|<>]/;
 
 export const formSchema = z.object({
   email: z.string()
@@ -13,9 +14,11 @@ export const formSchema = z.object({
 
   password: z.string()
     .min(8, { message: 'Password must be at least 8 characters long.' })
-    .max(20, { message: 'Password must be at most 20 characters long.' }),
+    .max(20, { message: 'Password must be at most 20 characters long.' })
+    .regex(passwordRegex, { message: 'Password must contain at least one special character.' }),
 
-    confirmPassword: z.string().min(8, { message: 'Password must be at least 8 characters long.' }),
+    confirmPassword: z.string().min(8, { message: 'Password must be at least 8 characters long.' })
+    .regex(passwordRegex, { message: 'Password must contain at least one special character.' }),
   }).superRefine((data, ctx) => {
     if (data.password !== data.confirmPassword) {
       ctx.addIssue({

--- a/src/routes/signup/sign-up-schema.ts
+++ b/src/routes/signup/sign-up-schema.ts
@@ -1,6 +1,8 @@
 // schema.ts
 import { z } from 'zod';
 const passwordRegex = /[!@#$%^&*(),.?":{}|<>]/;
+const capitalRegex = /[A-Z]/;
+const digitRegex = /\d/;
 
 export const formSchema = z.object({
   email: z.string()
@@ -15,9 +17,13 @@ export const formSchema = z.object({
   password: z.string()
     .min(8, { message: 'Password must be at least 8 characters long.' })
     .max(20, { message: 'Password must be at most 20 characters long.' })
-    .regex(passwordRegex, { message: 'Password must contain at least one special character.' }),
+    .regex(passwordRegex, { message: 'Password must contain at least one special character.' })
+    .regex(capitalRegex, { message: 'Password must contain at least one uppercase letter.' })
+    .regex(digitRegex, { message: 'Password must contain at least one digit.' }),
 
     confirmPassword: z.string().min(8, { message: 'Password must be at least 8 characters long.' })
+    .regex(digitRegex, { message: 'Password must contain at least one digit.' })
+    .regex(capitalRegex, { message: 'Password must contain at least one uppercase letter.' })
     .regex(passwordRegex, { message: 'Password must contain at least one special character.' }),
   }).superRefine((data, ctx) => {
     if (data.password !== data.confirmPassword) {


### PR DESCRIPTION
## Description

This pull request adds role based routing restrictions

### Resolved Issue
Fixes #80 

## Changes

We now extract the role from the jwt token, only after it has been validated buy the backend API.
Allowed routes are updated to reflect the roles
Fixed login not displaying backend error, if zod validation did not catch it

Current tests have been changed to include a student role on user objects. Tests including the instructor class should be considered

## Additional Information

Index page is now shown differently based on if you are a instructor or not. Perhaps the instructor home should be moved to its own route and not be on the main index.

## Checklist

- [X] I have added test cases for my additions - Tests for what routes are allowed for the roles are not fully implemented
- [X] New and old tests passed
- [X] Documentation is updated
